### PR TITLE
typo in README: change deploy,yaml to deploy.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ EOF
 
 ### Application deployment(Currently this has the gateway for both Argocd and the application)
 ```
-kubectl apply -f deploy/deploy,yaml
+kubectl apply -f deploy/deploy.yaml
 ```
 
 ## Argocd installation 


### PR DESCRIPTION
Fix typo in README: deploy,yaml -> deploy.yaml at line 137